### PR TITLE
Adding key to navigation node.

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -292,7 +292,7 @@ function report_editdates_extend_navigation_course($navigation, $course, $contex
             $url->param('activitytype', $activitytype);
         }
         $navigation->add(get_string( 'editdates', 'report_editdates' ),
-                $url, navigation_node::TYPE_SETTING, null, null, new pix_icon('i/report', ''));
+                $url, navigation_node::TYPE_SETTING, null, 'editdates', new pix_icon('i/report', ''));
     }
 }
 


### PR DESCRIPTION
This is needed because we are modifying the course settings page and currently cannot find the Edit Dates report without this key being added.