### PR TITLE
report_editdates: Update course and activity dates to support times.

### DIFF
--- a/form.php
+++ b/form.php
@@ -64,9 +64,12 @@ class report_editdates_form extends moodleform {
         // Course start date.
         $mform->addElement('header', 'coursestartdateheader', get_string('coursestartdateheader', 'report_editdates'));
         $mform->setExpanded('coursestartdateheader', false);
-        $mform->addElement('date_selector', 'coursestartdate', get_string('startdate'));
+        $mform->addElement('date_time_selector', 'coursestartdate', get_string('startdate'));
         $mform->addHelpButton('coursestartdate', 'startdate');
         $mform->setDefault('coursestartdate', $course->startdate);
+        $mform->addElement('date_time_selector', 'courseenddate', get_string('enddate'), array('optional' => true));
+        $mform->addHelpButton('courseenddate', 'enddate');
+        $mform->setDefault('courseenddate', $course->enddate);
 
         // If user is not capable, make it read only.
         if (!has_capability('moodle/course:update', $coursecontext)) {
@@ -181,7 +184,7 @@ class report_editdates_form extends moodleform {
                     // Completion tracking.
                     if ($coursehascompletion && $cm->completion) {
                         $elname = 'date_mod_'.$cm->id.'_completionexpected';
-                        $mform->addElement('date_selector', $elname,
+                        $mform->addElement('date_time_selector', $elname,
                                 get_string('completionexpected', 'completion'),
                                 array('optional' => true));
                         $mform->addHelpButton($elname, 'completionexpected', 'completion');

--- a/index.php
+++ b/index.php
@@ -108,43 +108,47 @@ if ($mform->is_cancelled()) {
         if ($key == "coursestartdate") {
             $course->startdate = $value;
         } else {
-            // It is a module. Need to extract date settings for each module.
-            $cmsettings = explode('_', $key);
-            // The array should have 4 keys.
-            if (count($cmsettings) == 4) {
-                // Ignore 0th position, it will be 'date'
-                // 1st position should be the mod type
-                // 2nd will be the id of module
-                // 3rd will be property of module
-                // ensure that the name is proper.
-                if (isset($cmsettings['1']) && isset($cmsettings['2']) && isset($cmsettings['3'])) {
-                    // Check if its mod date settings.
-                    if ($cmsettings['1'] == 'mod') {
-                        // Module context.
-                        $modcontext = context_module::instance($cmsettings['2']);
-                        // User should be capable of updating individual module.
-                        if (has_capability('moodle/course:manageactivities', $modcontext)) {
-                            // Check if config date settings are forced
-                            // and this is one of the forced date setting.
-                            if (($CFG->enablecompletion || $CFG->enableavailability)
-                                    && ($cmsettings['3'] == "completionexpected"
-                                    || $cmsettings['3'] == "availablefrom"
-                                    || $cmsettings['3'] == "availableuntil") ) {
-                                $forceddatesettings[$cmsettings['2']][$cmsettings['3']]=$value;
-                            } else {
-                                // Module date setting.
-                                $moddatesettings[$cmsettings['2']][$cmsettings['3']] = $value;
+            if ($key == "courseenddate") {
+                $course->enddate = $value;
+            } else {
+                // It is a module. Need to extract date settings for each module.
+                $cmsettings = explode('_', $key);
+                // The array should have 4 keys.
+                if (count($cmsettings) == 4) {
+                    // Ignore 0th position, it will be 'date'
+                    // 1st position should be the mod type
+                    // 2nd will be the id of module
+                    // 3rd will be property of module
+                    // ensure that the name is proper.
+                    if (isset($cmsettings['1']) && isset($cmsettings['2']) && isset($cmsettings['3'])) {
+                        // Check if its mod date settings.
+                        if ($cmsettings['1'] == 'mod') {
+                            // Module context.
+                            $modcontext = context_module::instance($cmsettings['2']);
+                            // User should be capable of updating individual module.
+                            if (has_capability('moodle/course:manageactivities', $modcontext)) {
+                                // Check if config date settings are forced
+                                // and this is one of the forced date setting.
+                                if (($CFG->enablecompletion || $CFG->enableavailability)
+                                        && ($cmsettings['3'] == "completionexpected"
+                                        || $cmsettings['3'] == "availablefrom"
+                                        || $cmsettings['3'] == "availableuntil") ) {
+                                    $forceddatesettings[$cmsettings['2']][$cmsettings['3']]=$value;
+                                } else {
+                                    // Module date setting.
+                                    $moddatesettings[$cmsettings['2']][$cmsettings['3']] = $value;
+                                }
                             }
-                        }
-                    } else if ($cmsettings['1'] == 'block') {
-                        // If user is capable of updating blocks in course context.
-                        if (has_capability('moodle/site:manageblocks', $coursecontext)) {
-                            $blockdatesettings[$cmsettings['2']][$cmsettings['3']] = $value;
-                        }
-                    } else if ($cmsettings['1'] == 'section') {
-                        // If user is capable of updating sections in course context.
-                        if (has_capability('moodle/course:update', $coursecontext)) {
-                            $sectiondatesettings[$cmsettings['2']][$cmsettings['3']] = $value;
+                        } else if ($cmsettings['1'] == 'block') {
+                            // If user is capable of updating blocks in course context.
+                            if (has_capability('moodle/site:manageblocks', $coursecontext)) {
+                                $blockdatesettings[$cmsettings['2']][$cmsettings['3']] = $value;
+                            }
+                        } else if ($cmsettings['1'] == 'section') {
+                            // If user is capable of updating sections in course context.
+                            if (has_capability('moodle/course:update', $coursecontext)) {
+                                $sectiondatesettings[$cmsettings['2']][$cmsettings['3']] = $value;
+                            }
                         }
                     }
                 }
@@ -157,6 +161,7 @@ if ($mform->is_cancelled()) {
     // Allow to update only if user is capable.
     if (has_capability('moodle/course:update', $coursecontext)) {
         $DB->set_field('course', 'startdate', $course->startdate, array('id' => $course->id));
+        $DB->set_field('course', 'enddate', $course->enddate, array('id' => $course->id));
     }
 
     // Update forced date settings.


### PR DESCRIPTION
Addresses changes required to support features added to Moodle core in version 3.5.
Specifically:
1. Activity completion can have a time associated rather than just a date (See MDL-61205)
2. Course start & end dates can be other than Midnight (See MDL-43648)