### PR TITLE
Adding node key

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -315,7 +315,7 @@ function report_editdates_extend_navigation_course($navigation, $course, $contex
             $url->param('activitytype', $activitytype);
         }
         $navigation->add(get_string( 'editdates', 'report_editdates' ),
-                $url, navigation_node::TYPE_SETTING, null, null, new pix_icon('i/report', ''));
+                $url, navigation_node::TYPE_SETTING, null, 'editdates', new pix_icon('i/report', ''));
     }
 }
 


### PR DESCRIPTION
We have a plugin that reorders/renames links in the navigation nodes, but we cannot do anything with the editdates report node since there is no key specified. This patch adds a key and should not affect anything else with the plugin.