### PR TITLE
PHP8.1+: removed deprecated legacy functions

### DIFF
--- a/classes/event/report_viewed.php
+++ b/classes/event/report_viewed.php
@@ -79,23 +79,4 @@ EOF;
         return new \moodle_url('/report/editdates/index.php', $params);
     }
 
-    public static function get_legacy_eventname() {
-        return 'report edit dates';
-    }
-
-    /**
-     * Return the legacy event log data.
-     *
-     * @return array|null
-     */
-    protected function get_legacy_logdata() {
-        return array(
-                $this->courseid,
-                "course",
-                "report edit dates",
-                "report/editdates/index.php?id={$this->courseid}",
-                $this->contextinstanceid
-        );
-    }
-
 }


### PR DESCRIPTION
Legacy functions are deprecated now. 
This will fix #61.